### PR TITLE
remove useless mongodb in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.100
-
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.11.0
-        with:
-          mongodb-version: '8.0'
   
       - name: Build & Test
         run: make test config=Release


### PR DESCRIPTION
MongoDB is running on GitHub actions... not that terribly useful... maybe if integration tests are coming back. Until then, it's removed.