### PR TITLE
Change register() namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ FSharp.MongoDB | [![Nuget](https://img.shields.io/nuget/v/FSharp.MongoDB)](https
 
 On startup you have to register serializers:
 ```ocaml
-MongoDB.Bson.Serialization.FSharpSerializer.register()
+MongoDB.Bson.Serialization.FSharp.register()
 ```
 
 # License

--- a/src/FSharp.MongoDB.Bson/Serialization/FSharpValueSerializer.fs
+++ b/src/FSharp.MongoDB.Bson/Serialization/FSharpValueSerializer.fs
@@ -22,7 +22,7 @@ open MongoDB.Bson.Serialization.Serializers
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 [<RequireQualifiedAccess>]
-module FSharpSerializer =
+module FSharp =
 
     /// <summary>
     /// Provides (de)serialization of F# data types, including lists, maps, options, records, sets,

--- a/tests/FSharp.MongoDB.Bson.Tests/SerializationTestHelpers.fs
+++ b/tests/FSharp.MongoDB.Bson.Tests/SerializationTestHelpers.fs
@@ -23,7 +23,7 @@ open MongoDB.Bson.Serialization
 module Helpers =
 
     let serialize<'T> (value: 'T) =
-        FSharpSerializer.register()
+        FSharp.register()
 
         let doc = BsonDocument()
         use writer = new BsonDocumentWriter(doc, BsonDocumentWriterSettings.Defaults)
@@ -33,7 +33,7 @@ module Helpers =
         doc
 
     let deserialize<'T> doc =
-        FSharpSerializer.register()
+        FSharp.register()
 
         use reader = new BsonDocumentReader(doc, BsonDocumentReaderSettings.Defaults)
         BsonSerializer.Deserialize<'T>(reader)


### PR DESCRIPTION
`register()` now lives in `MongoDB.Bson.Serialization` namespace.