### PR TITLE
remove suffix Module on namespace for better C# interop

### DIFF
--- a/src/FSharp.MongoDB.Bson/Serialization/FSharpValueSerializer.fs
+++ b/src/FSharp.MongoDB.Bson/Serialization/FSharpValueSerializer.fs
@@ -20,7 +20,6 @@ open MongoDB.Bson.Serialization.Conventions
 open MongoDB.Bson.Serialization.Helpers
 open MongoDB.Bson.Serialization.Serializers
 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 [<RequireQualifiedAccess>]
 module FSharp =
 


### PR DESCRIPTION
Namespace was `MongoDB.Bson.Serialization.FSharp` for F# and `MongoDB.Bson.Serialization.FSharpModule` for C#.
Unify this under `MongoDB.Bson.Serialization.FSharp`.